### PR TITLE
PT-4349: JTL5 | Upgrade JTL5 plugin to support 8.2 - 8.5 and latest JTL5

### DIFF
--- a/Src/Controllers/Frontend/InvoicesController.php
+++ b/Src/Controllers/Frontend/InvoicesController.php
@@ -46,7 +46,9 @@ class InvoicesController
         }
 
         $invoiceData = [
-            'currency' => $bestellung->Waehrung->code,
+            'currency' => method_exists($bestellung->Waehrung, 'getCode')
+                ? $bestellung->Waehrung->getCode()
+                : $bestellung->Waehrung->code,
             'order_uuid' => $monduOrder->order_uuid,
             'external_reference_id' => (string) $invoiceId,
             'invoice_url' => 'http://localhost',

--- a/Src/Helpers/BasketHelper.php
+++ b/Src/Helpers/BasketHelper.php
@@ -63,11 +63,22 @@ class BasketHelper
             }
 
             if ($amount !== 0) {
-                Frontend::getCart()->erstelleSpezialPos(
+                $cart = Frontend::getCart();
+                if (\method_exists($cart, 'gibVersandkostenSteuerklasse')) {
+                    $taxClassID = $cart->gibVersandkostenSteuerklasse();
+                } else {
+                    $taxRateIDs = $cart->getShippingService()->getTaxRateIDs(
+                        '',
+                        $cart->PositionenArr,
+                        $_SESSION['Lieferadresse']->cLand ?? '',
+                    );
+                    $taxClassID = $taxRateIDs[0]->taxRateID ?? 0;
+                }
+                $cart->erstelleSpezialPos(
                     $name,
                     1,
                     $amount,
-                    Frontend::getCart()->gibVersandkostenSteuerklasse(),
+                    $taxClassID,
                     \C_WARENKORBPOS_TYP_ZAHLUNGSART
                 );
             }

--- a/Src/Support/Facades/Router/Route.php
+++ b/Src/Support/Facades/Router/Route.php
@@ -157,7 +157,7 @@ class Route
         return RouteHandler::call($action, $pluginId);
     }
 
-    public static function execute($controllerMethod, int $pluginId = null)
+    public static function execute($controllerMethod, ?int $pluginId = null)
     {
         return RouteHandler::call($controllerMethod, $pluginId);
     }

--- a/Src/Support/Facades/Router/RouteHandler.php
+++ b/Src/Support/Facades/Router/RouteHandler.php
@@ -6,7 +6,7 @@ class RouteHandler
 {
     private const CONTROLLERS_NAMESPACE = 'Plugin\\MonduPayment\\Src\\Controllers\\';
 
-    public static function call($handler, int $pluginId = null, $middlewares = [])
+    public static function call($handler, ?int $pluginId = null, $middlewares = [])
     {
         foreach ($middlewares as $middleware) {
             MiddlewareHandler::call($middleware);

--- a/Src/Support/Http/HttpRequest.php
+++ b/Src/Support/Http/HttpRequest.php
@@ -44,7 +44,7 @@ class HttpRequest
      * @return array
      * @throws InvalidRequestException
      */
-    public function get(string $url, array $data = [], array $headers = null)
+    public function get(string $url, array $data = [], ?array $headers = null)
     {
         $url = $this->baseUrl . $url;
         $this->headers = $headers == null ? $this->headers : $headers;
@@ -61,7 +61,7 @@ class HttpRequest
      * @return array
      * @throws InvalidRequestException
      */
-    public function post(string $url, array $data = [], array $headers = null)
+    public function post(string $url, array $data = [], ?array $headers = null)
     {
         $url = $this->baseUrl . $url;
         $this->headers = $headers == null ? $this->headers : $headers;

--- a/frontend/hooks/CheckoutPaymentMethod.php
+++ b/frontend/hooks/CheckoutPaymentMethod.php
@@ -127,7 +127,7 @@ class CheckoutPaymentMethod
      *
      * @return string
      */
-    private function __translate($original): string
+    private function translateText($original): string
     {
       $getText   = Shop::Container()->getGetText();
       $oldLocale = $getText->getLanguage();
@@ -168,7 +168,7 @@ class CheckoutPaymentMethod
             });
             
             foreach ($methods as $method) {
-                $method->monduBenefits = str_replace('{net_term}', $netTerm, $this->__translate($benefits['invoice']));
+                $method->monduBenefits = str_replace('{net_term}', $netTerm, $this->translateText($benefits['invoice']));
                 $method->monduNetTerm = $netTerm; // Store net term for sorting
                 $method->cBild = $this->getPaymentMethodImage('invoice'); // Set localized image
                 $invoiceMethods[] = $method;
@@ -185,10 +185,10 @@ class CheckoutPaymentMethod
             
             $uniqueNetTerms = array_unique($invoiceNetTerms);
             sort($uniqueNetTerms);
-            $netTermsText = implode(', ', $uniqueNetTerms) . ' ' . $this->__translate('Tage');
+            $netTermsText = implode(', ', $uniqueNetTerms) . ' ' . $this->translateText('Tage');
             
             $monduGroups[] = [
-                'title' => $this->__translate('Rechnungskauf') . ' (' . $netTermsText . ')',
+                'title' => $this->translateText('Rechnungskauf') . ' (' . $netTermsText . ')',
                 'description' => '',
                 'image' => $this->getPaymentMethodImage('invoice'),
                 'payment_methods' => $invoiceMethods
@@ -208,7 +208,7 @@ class CheckoutPaymentMethod
             });
             
             foreach ($methods as $method) {
-                $method->monduBenefits = str_replace('{net_term}', $netTerm, $this->__translate($benefits['direct_debit']));
+                $method->monduBenefits = str_replace('{net_term}', $netTerm, $this->translateText($benefits['direct_debit']));
                 $method->monduNetTerm = $netTerm; // Store net term for sorting
                 $method->cBild = $this->getPaymentMethodImage('direct_debit'); // Set localized image
                 $sepaMethods[] = $method;
@@ -225,10 +225,10 @@ class CheckoutPaymentMethod
             
             $uniqueNetTerms = array_unique($sepaNetTerms);
             sort($uniqueNetTerms);
-            $netTermsText = implode(', ', $uniqueNetTerms) . ' ' . $this->__translate('Tage');
+            $netTermsText = implode(', ', $uniqueNetTerms) . ' ' . $this->translateText('Tage');
             
             $monduGroups[] = [
-                'title' => $this->__translate('SEPA-Lastschrift') . ' (' . $netTermsText . ')',
+                'title' => $this->translateText('SEPA-Lastschrift') . ' (' . $netTermsText . ')',
                 'description' => '',
                 'image' => $this->getPaymentMethodImage('direct_debit'),
                 'payment_methods' => $sepaMethods
@@ -247,7 +247,7 @@ class CheckoutPaymentMethod
         foreach ($installmentPaymentMethods as $method) {
             $paymentMethodType = $this->configService->getPaymentMethodByKPlugin($method->cModulId);
             if (isset($benefits[$paymentMethodType]) && $benefits[$paymentMethodType]) {
-                $method->monduBenefits = $this->__translate($benefits[$paymentMethodType]);
+                $method->monduBenefits = $this->translateText($benefits[$paymentMethodType]);
             } else {
                 $method->monduBenefits = '';
             }
@@ -266,10 +266,10 @@ class CheckoutPaymentMethod
         if (count($installmentPaymentMethods) > 0) {
             $uniquePeriods = array_unique($installmentPeriods);
             sort($uniquePeriods, SORT_NUMERIC);
-            $periodsText = implode(', ', $uniquePeriods) . ' ' . $this->__translate('Monaten');
+            $periodsText = implode(', ', $uniquePeriods) . ' ' . $this->translateText('Monaten');
             
             $monduGroups[] = [
-                'title' => $this->__translate('Ratenkauf') . ' (' . $periodsText . ')',
+                'title' => $this->translateText('Ratenkauf') . ' (' . $periodsText . ')',
                 'description' => '',
                 'image' => $this->getPaymentMethodImage('installment'),
                 'payment_methods' => $installmentPaymentMethods

--- a/info.xml
+++ b/info.xml
@@ -7,7 +7,7 @@
     <PluginID>MonduPayment</PluginID>
     <XMLVersion>100</XMLVersion>
     <ShopVersion>5.0.0</ShopVersion>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <CreateDate>2022-06-07</CreateDate>
     <Install>
         <Hooks>


### PR DESCRIPTION
**Summary**
This PR makes the Mondu JTL5 plugin compatible with PHP 8.2 through 8.5 and the latest JTL5 release. It addresses deprecations introduced in recent PHP versions and adapts to API changes in the JTL5 core.

**Changes**
PHP 8.4+ compatibility - explicit nullable parameter types
PHP 8.4 deprecates implicitly nullable parameter declarations. Updated the affected signatures to use explicit nullable types:
- Src/Support/Facades/Router/Route.php - execute(..., ?int $pluginId = null)
- Src/Support/Facades/Router/RouteHandler.php - call(..., ?int $pluginId = null, ...)
- Src/Support/Http/HttpRequest.php - get() / post() now use ?array $headers = null

**Reserved method name fix**
Renamed __translate() to translateText() in frontend/hooks/CheckoutPaymentMethod.php. Method names with a leading double underscore are reserved by PHP for magic methods; all call sites were updated
accordingly.

**Latest JTL5 core API compatibility**
- Src/Controllers/Frontend/InvoicesController.php - read the currency code via Waehrung->getCode() when available, falling back to the legacy -> code property for older JTL5 versions.
- Src/Helpers/BasketHelper.php - resolve the shipping tax class via the new getShippingService()->getTaxRateIDs() API when gibVersandkostenSteuerklasse() is no longer present, with a fallback to the legacy
method to keep backward compatibility.

**Version bump**
- info.xml - plugin version 4.0.1 → 4.0.2.

**Backward compatibility**
All JTL5 API adaptations use method_exists() guards with fallbacks to the legacy calls, so the plugin keeps working on older JTL5 versions while supporting the latest release.

**Testing**
- Verified plugin loads and checkout payment methods render under PHP 8.2–8.5.
- Confirmed invoice creation and shipping/payment surcharge positions work on both legacy and latest JTL5 cores.


Fixes # (issue)
https://mondu.atlassian.net/browse/PT-4349

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings