### PR TITLE
PT-4467: JTL5 | JTL WaWi issue

### DIFF
--- a/PaymentMethod/MonduPayment.php
+++ b/PaymentMethod/MonduPayment.php
@@ -92,6 +92,16 @@ class MonduPayment extends Method
 
         $state = $monduOrderApi['order']['state'] ?? null;
 
+        if ($state === null) {
+            // getOrder response did not contain order.state: the order is held from the Wawi
+            // (fail-closed) and will only release on an order/confirmed webhook. Log it so an
+            // empty/failed Mondu response is diagnosable instead of the order being silently stuck.
+            Shop::Container()->getLogService()->warning(
+                'Mondu: could not read order state from getOrder response for order ' . $order->cBestellNr
+                . '; holding it from the Wawi until an order/confirmed webhook arrives.'
+            );
+        }
+
         if ($configService->shouldMarkOrderAsPaid()) {
             $payValue = $order->fGesamtsumme;
             $hash = $this->generateHash($order);
@@ -114,8 +124,18 @@ class MonduPayment extends Method
         // This stops created-but-cancelled/unconfirmed orders from being transmitted.
         if ($state !== MonduPayment::STATE_CONFIRMED) {
             $upd            = new \stdClass();
-            $upd->cStatus   = \BESTELLUNG_STATUS_IN_BEARBEITUNG;
+            // Hold the order back from the Wawi for every non-confirmed state.
             $upd->cAbgeholt = 'M';
+
+            // Only reflect a status the state actually justifies: pending -> In Bearbeitung,
+            // declined/canceled -> Storno (consistent with WebhookController::MONDU_JTL_MAPPING).
+            // Unknown/empty states are just held from the Wawi without forcing a misleading status.
+            if ($state === MonduPayment::STATE_PENDING) {
+                $upd->cStatus = \BESTELLUNG_STATUS_IN_BEARBEITUNG;
+            } elseif ($state === MonduPayment::STATE_DECLINED || $state === MonduPayment::STATE_CANCELED) {
+                $upd->cStatus = \BESTELLUNG_STATUS_STORNO;
+            }
+
             Shop::Container()->getDB()->update('tbestellung', 'kBestellung', (int) $order->kBestellung, $upd);
         }
 

--- a/PaymentMethod/MonduPayment.php
+++ b/PaymentMethod/MonduPayment.php
@@ -90,6 +90,8 @@ class MonduPayment extends Method
             'authorized_net_term' => $authorizedNetTerm
         ]);
 
+        $state = $monduOrderApi['order']['state'] ?? null;
+
         if ($configService->shouldMarkOrderAsPaid()) {
             $payValue = $order->fGesamtsumme;
             $hash = $this->generateHash($order);
@@ -101,15 +103,20 @@ class MonduPayment extends Method
                 'cHinweis' => $_SESSION['monduOrderUuid'],
             ]);
 
-            if ($monduOrderApi['order']['state'] === MonduPayment::STATE_CONFIRMED) {
+            if ($state === MonduPayment::STATE_CONFIRMED) {
                 $this->setOrderStatusToPaid($order);
-            } else if ($monduOrderApi['order']['state'] === MonduPayment::STATE_PENDING) {
-                $upd                = new \stdClass();
-                $upd->cStatus       = \BESTELLUNG_STATUS_IN_BEARBEITUNG;
-                // Prevent Wawi sync for pending orders
-                $upd->cAbgeholt = 'M';
-                Shop::Container()->getDB()->update('tbestellung', 'kBestellung', (int) $order->kBestellung, $upd);
             }
+        }
+
+        // Prevent Wawi sync for every order that is not confirmed yet, regardless of
+        // the "mark order as paid" setting. The order is released for the Wawi only
+        // when Mondu confirms it (order/confirmed webhook -> unlockOrderForWawiSync).
+        // This stops created-but-cancelled/unconfirmed orders from being transmitted.
+        if ($state !== MonduPayment::STATE_CONFIRMED) {
+            $upd            = new \stdClass();
+            $upd->cStatus   = \BESTELLUNG_STATUS_IN_BEARBEITUNG;
+            $upd->cAbgeholt = 'M';
+            Shop::Container()->getDB()->update('tbestellung', 'kBestellung', (int) $order->kBestellung, $upd);
         }
 
         unset($_SESSION['monduOrderUuid']);

--- a/Src/Controllers/Frontend/WebhookController.php
+++ b/Src/Controllers/Frontend/WebhookController.php
@@ -53,12 +53,13 @@ class WebhookController
             switch ($requestData['topic']) {
                 case 'order/confirmed':
                 case 'order/declined':
+                case 'order/canceled':
                 case 'order/pending':
                     return $this->handleOrderStateChanged($requestData);
                 case 'invoice/canceled':
                     return $this->handleInvoiceStateChanged($requestData, 'canceled');
                 default:
-                    return [['message' => 'Unregistered topic: ' . $requestData['topic'], 'available_topics' => ['order/confirmed', 'order/declined', 'order/pending', 'invoice/canceled']], Response::HTTP_OK];
+                    return [['message' => 'Unregistered topic: ' . $requestData['topic'], 'available_topics' => ['order/confirmed', 'order/declined', 'order/canceled', 'order/pending', 'invoice/canceled']], Response::HTTP_OK];
             }
         } catch (\Exception $e) {
             return [['message' => 'Error processing webhook', 'error' => $e->getMessage()], Response::HTTP_INTERNAL_SERVER_ERROR];

--- a/Src/Controllers/Frontend/WebhookController.php
+++ b/Src/Controllers/Frontend/WebhookController.php
@@ -73,9 +73,17 @@ class WebhookController
      */
     public function handleOrderStateChanged($requestData)
     {
+        // Prefer the explicit order_state from the payload, but fall back to the topic
+        // (e.g. "order/canceled" -> "canceled") so the status mapping (incl. the STORNO
+        // transition) is guaranteed even if the payload does not populate order_state.
+        $orderState = $requestData['order_state'] ?? null;
+        if (empty($orderState) && isset($requestData['topic']) && strpos($requestData['topic'], 'order/') === 0) {
+            $orderState = substr($requestData['topic'], strlen('order/'));
+        }
+
         $params = [
             'order_id' => $requestData['external_reference_id'],
-            'order_state' => $requestData['order_state']
+            'order_state' => $orderState
         ];
 
         $monduOrder = $this->getOrder($params['order_id']);

--- a/info.xml
+++ b/info.xml
@@ -7,7 +7,7 @@
     <PluginID>MonduPayment</PluginID>
     <XMLVersion>100</XMLVersion>
     <ShopVersion>5.0.0</ShopVersion>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
     <CreateDate>2022-06-07</CreateDate>
     <Install>
         <Hooks>


### PR DESCRIPTION
## Description

This PR is fixiing cancelled/unconfirmed Mondu orders being transmitted to the JTL WaWi by holding back every non-confirmed order from the WaWi and only releasing it once Mondu sends the order/confirmed webhook (plus handling order/canceled so cancellations become STORNO in JTL).

Tickets: [PT-3173](https://mondu.atlassian.net/browse/PT-4467)

Fixes # (issue)
https://mondu.atlassian.net/browse/PT-4467

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked my code and corrected any misspellings

[PT-3173]: https://mondu.atlassian.net/browse/PT-3173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ